### PR TITLE
Adjust the git commands to run properly on Windows.

### DIFF
--- a/bin/phpcs-diff
+++ b/bin/phpcs-diff
@@ -13,8 +13,8 @@ namespace PHPCSDiff;
 
 use PHPCSDiff\Log\LoggerInterface;
 
-define( 'PHPCS_DIFF_PLUGIN_DIR', dirname( dirname( __FILE__ ) ) );
-define( 'PHPCS_DIFF_COMMAND', PHPCS_DIFF_PLUGIN_DIR . '/vendor/bin/phpcs' );
+define( 'PHPCS_DIFF_PLUGIN_DIR', str_replace('\\', '/', dirname( dirname( __FILE__ ) ) ) );
+define( 'PHPCS_DIFF_COMMAND', '"' . PHPCS_DIFF_PLUGIN_DIR . '/vendor/bin/phpcs' . '"' );
 define( 'PHPCS_DIFF_STANDARDS', PHPCS_DIFF_PLUGIN_DIR . '/standards' );
 
 const OUTPUT_BOLD = "\033[1m";

--- a/inc/backends/Git.php
+++ b/inc/backends/Git.php
@@ -144,7 +144,7 @@ class Git implements BackendInterface {
 		) );
 
 		$git_command = sprintf(
-			'git show --format=raw \'%s:%s\'',
+			'git show --format=raw %s:%s',
 			$revision,
 			ltrim( $filename, '/' )
 		);


### PR DESCRIPTION
Without these changes, the `phpcs` does not run in Windows, basically because of path issues. 

Also `git show` doesn't need to enclose the revision item inside single quotes.