### PR TITLE
Allow to exclude from the testing files with an invalid extension by using the "excluded_exts" argument with a comma-separated list of excluded extensions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea/
 /vendor/
 /standards/VariableAnalysis
 /standards/WordPress

--- a/bin/phpcs-diff
+++ b/bin/phpcs-diff
@@ -44,6 +44,7 @@ $getopt = new \GetOpt\GetOpt(
         [ 'no_colours', \GetOpt\GetOpt::NO_ARGUMENT ],
         [ 'colour_primary', \GetOpt\GetOpt::REQUIRED_ARGUMENT ],
         [ 'colour_secondary', \GetOpt\GetOpt::REQUIRED_ARGUMENT ],
+		[ 'excluded_exts', \GetOpt\GetOpt::OPTIONAL_ARGUMENT ],
 	]
 );
 
@@ -73,6 +74,7 @@ $phpcs_standard = $getopt->getOption( 'standard' );
 $log_level = $getopt->getOption( 'log_level' );
 $ignore_space_changes = $getopt->offsetExists( 'ignore_space_changes' );
 $no_colours = $getopt->offsetExists( 'no_colours' );
+$excluded_exts = $getopt->getOption( 'excluded_exts' );
 
 $sniff_unstaged = $getopt->offsetExists( 'sniff_unstaged' );
 if( $sniff_unstaged ) {
@@ -127,7 +129,7 @@ $controller = new Main( $version_control, $logger, $options );
 $controller->set_phpcs_standard( $phpcs_standard );
 
 try {
-	$found_issues = $controller->run( $start_revision, $end_revision, '' );
+	$found_issues = $controller->run( $start_revision, $end_revision, '', $excluded_exts );
 } catch ( \Exception $e ) {
 	$logger->log(
 		LoggerInterface::ERROR,

--- a/inc/Main.php
+++ b/inc/Main.php
@@ -65,19 +65,23 @@ class Main {
 	}
 
 	public function set_excluded_extensions( $excluded_exts ) {
-		if ( false === is_array( $excluded_exts) ) {
+		if ( false === is_array( $excluded_exts ) ) {
 			$excluded_exts = explode( ',', $excluded_exts );
 		}
 		$this->excluded_extensions = $excluded_exts;
 	}
 
-	public function run( $oldest_rev, $newest_rev, $directory = '' ) {
+	public function run( $oldest_rev, $newest_rev, $directory = '', $excluded_exts = '' ) {
 
 		if ( true !== $this->nocache ) {
 			$found_issues = false; //wp_cache_get( $cache_key, $cache_group );
 			if ( false !== $found_issues ) {
 				return $found_issues;
 			}
+		}
+
+		if ( '' !== $excluded_exts ) {
+			$this->set_excluded_extensions( $excluded_exts );
 		}
 
 		$diff  = trim( $this->version_control->get_diff( $directory, $newest_rev, $oldest_rev, [] ) );
@@ -146,7 +150,13 @@ class Main {
 		}
 
 		foreach( $this->excluded_extensions as $excluded_ext ) {
-			if ( function_exists( 'wp_endswith' ) && wp_endswith( $filename, $excluded_ext ) ) {
+			if (
+				(
+					function_exists( 'wp_endswith' ) &&
+					wp_endswith( $filename, $excluded_ext )
+				) ||
+				$excluded_ext === pathinfo( $filename, PATHINFO_EXTENSION )
+			) {
 				return false;
 			}
 		}


### PR DESCRIPTION
By using the `--excluded_ext=js` for example you are omitting the JS files from the test.