### PR TITLE
Add a new JSON format response so it can be used as an API.

### DIFF
--- a/bin/phpcs-diff
+++ b/bin/phpcs-diff
@@ -29,7 +29,6 @@ const OUTPUT_UNDERLINED = "\033[4m";
 const OUTPUT_UNUNDERLINED = "\033[24m";
 
 $logo = file_get_contents( PHPCS_DIFF_PLUGIN_DIR . '/logo' );
-echo "\n$logo\n" . OUTPUT_UNDERLINED . COLOUR_SECONDARY . 'https://github.com/zaantar/phpcs-diff' . OUTPUT_RESET . "\n\n";
 
 require_once PHPCS_DIFF_PLUGIN_DIR . '/vendor/autoload.php';
 
@@ -48,6 +47,7 @@ $getopt = new GetOpt(
 		[ 'excluded_exts', GetOpt::OPTIONAL_ARGUMENT ],
 		[ 'standards_location', GetOpt::OPTIONAL_ARGUMENT ],
 		[ 'default_standards_location', GetOpt::NO_ARGUMENT ],
+		[ 'format', GetOpt::OPTIONAL_ARGUMENT ],
 	]
 );
 
@@ -83,6 +83,8 @@ $no_colours = $getopt->offsetExists( 'no_colours' );
 $excluded_exts = $getopt->getOption( 'excluded_exts' );
 $standards_location = $getopt->getOption( 'standards_location' );
 $default_standards_location = $getopt->getOption( 'default_standards_location' );
+$format = $getopt->getOption( 'format' );
+$do_echo = $format !== 'json';
 
 $sniff_unstaged = $getopt->offsetExists( 'sniff_unstaged' );
 if ( $sniff_unstaged ) {
@@ -137,10 +139,14 @@ if( $default_standards_location ) {
 }
 
 $logger = new Log\ShellLogger( (int) $log_level );
-$options = [ 'ignore-space-change' => $ignore_space_changes, 'standards_location' => $standards_location ];
+$options = [ 'ignore-space-change' => $ignore_space_changes, 'standards_location' => $standards_location, 'format' => $format ];
 $version_control = new Backends\Git( '', $logger, $options );
 $controller = new Main( $version_control, $logger, $options );
 $controller->set_phpcs_standard( $phpcs_standard );
+
+if ( $do_echo ) {
+	echo "\n$logo\n" . OUTPUT_UNDERLINED . COLOUR_SECONDARY . 'https://github.com/zaantar/phpcs-diff' . OUTPUT_RESET . "\n\n";
+}
 
 try {
 	$found_issues = $controller->run( $start_revision, $end_revision, '', $excluded_exts );
@@ -199,6 +205,15 @@ function echo_chapter( $title, $items ) {
 	}
 
 	echo PHP_EOL;
+}
+
+if ( $format === 'json' ) {
+	echo json_encode( array(
+		'blockers' => $blockers,
+		'warnings' => $warnings,
+		'notes' => $notes,
+	) );
+	exit();
 }
 
 echo PHP_EOL;

--- a/inc/Main.php
+++ b/inc/Main.php
@@ -26,6 +26,8 @@ class Main {
 
 	private $no_diff_to_big = false;
 
+	private $format = false;
+
 	/** @var LoggerInterface */
 	private $log;
 
@@ -50,6 +52,7 @@ class Main {
 		$this->allowed_extensions = array( 'php', 'js' );
 
 		$this->log = $log;
+		$this->log->set_enable( $this->format !== 'json' );
 	}
 
 	public function set_nocache( $nocache = false ) {

--- a/inc/log/LoggerInterface.php
+++ b/inc/log/LoggerInterface.php
@@ -23,4 +23,11 @@ interface LoggerInterface {
 	 */
 	public function log( $severity, $message );
 
+	/**
+	 * @param $enable boolea
+	 *
+	 * @return void
+	 */
+	public function set_enable( $enable );
+
 }

--- a/inc/log/ShellLogger.php
+++ b/inc/log/ShellLogger.php
@@ -6,7 +6,7 @@ namespace PHPCSDiff\Log;
 class ShellLogger implements LoggerInterface {
 
 	private $log_level;
-
+	private $enable = true;
 
 	public function __construct( $log_level = LoggerInterface::WARNING ) {
 		$this->log_level = $log_level;
@@ -20,7 +20,7 @@ class ShellLogger implements LoggerInterface {
 	 */
 	public function log( $severity, $message ) {
 
-		if( $this->log_level > $severity ) {
+		if( $this->log_level > $severity || ! $this->enable ) {
 			return;
 		}
 
@@ -36,4 +36,14 @@ class ShellLogger implements LoggerInterface {
 				break;
 		}
 	}
+
+	/**
+	 * @param $enable boolea
+	 *
+	 * @return void
+	 */
+	public function set_enable( $enable ) {
+		$this->enable = $enable;
+	}
+
 }

--- a/inc/log/WpcliLogger.php
+++ b/inc/log/WpcliLogger.php
@@ -10,6 +10,7 @@ namespace PHPCSDiff\Log;
  * @package PHPCSDiff\Log
  */
 class WpcliLogger implements LoggerInterface {
+	private $enable = true;
 
 	/** @noinspection PhpDocMissingThrowsInspection */
 	/**
@@ -19,6 +20,10 @@ class WpcliLogger implements LoggerInterface {
 	 * @return void
 	 */
 	public function log( $severity, $message ) {
+		if ( ! $this->enable ) {
+			return;
+		}
+
 		switch( $severity ) {
 			case LoggerInterface::ERROR:
 				/** @noinspection PhpUnhandledExceptionInspection */
@@ -32,6 +37,15 @@ class WpcliLogger implements LoggerInterface {
 				\WP_CLI::log( $message );
 				break;
 		}
+	}
+
+	/**
+	 * @param $enable boolea
+	 *
+	 * @return void
+	 */
+	public function set_enable( $enable ) {
+		$this->enable = $enable;
 	}
 
 }


### PR DESCRIPTION
I am developing an extension for VS Code that uses Toolset PHPCS Diff to display errors. 

Most popular PHPCS code extension usually takes a lot of CPU usage and I don't really need that for working